### PR TITLE
Set correct Content-Type for JSON responses

### DIFF
--- a/src/routes/objects.js
+++ b/src/routes/objects.js
@@ -152,6 +152,7 @@ export function requestObject(app) {
                 );
               } else {
                 // if format .json redirect to machine-readable page.
+                res.set('Content-Type', 'application/json+ld;charset=utf-8')
                 res.send(result_cidoc[0]["LDES_raw"]["object"]);
               }
               //todo: add route to page when not published yet. -- this object has not been published yet.


### PR DESCRIPTION
The Content-Type for JSON responses has now been set to 'application/json+ld;charset=utf-8'. This ensures the proper handling and interpretation of JSON responses by both the client and server applications.