### PR TITLE
Disable JSON-LD content type setting in root route

### DIFF
--- a/src/routes/dcat.js
+++ b/src/routes/dcat.js
@@ -2,7 +2,7 @@ import negotiate from "express-negotiate";
 
 export function requestDCAT(app) {
   app.get("/", (req, res) => {
-    res.set('Content-Type', 'application/json+ld;charset=utf-8')
+    //res.set('Content-Type', 'application/json+ld;charset=utf-8')
     res.send({
       "@context": [
         "https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/erkendestandaard/2022-04-21/context/DCAT-AP-VL-20.jsonld",


### PR DESCRIPTION
The 'Content-Type' setting of 'application/json+ld;charset=utf-8' has been commented out in the application's root route. This code change temporarily disables the setting of this specific content type for responses in the root route. It remains active and unchanged for other routes.