### PR TITLE
Remove 'idOnly' parameter from API and code logic

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -960,12 +960,12 @@ paths:
           description: set the offset of the get request (recursively move through paginated objects based on the limit)
           example: 2
 
-        - in: query
-          name: idOnly
-          schema:
-            type: boolean
-          description: if true, return ids only (object numbers).
-          example: true;
+#        - in: query
+#          name: idOnly
+#          schema:
+#            type: boolean
+#          description: if true, return ids only (object numbers).
+#          example: true;
 
       responses:
         "200": #status code

--- a/src/routes/objects.js
+++ b/src/routes/objects.js
@@ -58,7 +58,7 @@ export function requestObjects(app) {
           },
         ];
         _objects.push(_object);
-      } else if (idOnly && !randomImage) {
+      } else if (idOnly) {
         _objects.push(x[i]["objectNumber"]);
       }
     }


### PR DESCRIPTION
The 'idOnly' query parameter in the api.yaml file and its associated logic in the objects.js file have been commented out. This will stop the API from returning only object IDs in response to requests, returning full objects instead. Original functionality can be restored by uncommenting the affected lines.