### PR TITLE
Remove unnecessary async from color request handler

### DIFF
--- a/src/routes/colors.js
+++ b/src/routes/colors.js
@@ -4,7 +4,7 @@ import {fetchAllLDESrecordsObjects} from "../utils/parsers.js";
 
 export function requestByColor(app) {
 
-    app.get('/colors/', async(req, res) => {
+    app.get('/colors/', (req, res) => {
         res.status(200).send(colors_dict)
     })
 


### PR DESCRIPTION
The async keyword was removed from the GET /colors/ route handler since there are no asynchronous operations in the function. This change simplifies the code and removes unnecessary overhead.