### PR TITLE
Add iiif_image_uris to LDES records fetch

### DIFF
--- a/src/utils/parsers.js
+++ b/src/utils/parsers.js
@@ -44,7 +44,7 @@ export async function fetchAllPrivateLDESrecordsObjects(rangeStart, rangeEnd) {
 export async function fetchAllLDESrecordsObjects() {
   const { data } = await supabase
     .from("dmg_objects_LDES")
-    .select("objectNumber, iiif_manifest, color_names, HEX_values, LDES_raw");
+    .select("objectNumber, iiif_image_uris, iiif_manifest, color_names, HEX_values, LDES_raw");
   return data;
 }
 


### PR DESCRIPTION
Updated the fetchAllLDESrecordsObjects function to include iiif_image_uris in the selected fields from the dmg_objects_LDES table. This change ensures that image URIs are retrieved along with other object data.