### PR TITLE
Update texts endpoint and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ these include various collections:
 * **objects** (private): [https://data.designmuseumgent.be/v1/id/private-objects](https://data.designmuseumgent.be/v1/id/private-objects)
 * **exhibitions** (events): [https://data.designmuseumgent.be/v1/id/exhibitions](https://data.designmuseumgent.be/v1/id/exhibitions)
 * **billboard series**: [https://data.designmuseumgent.be/v1/id/exhibitions/billboardseries](https://data.designmuseumgent.be/v1/id/exhibitions/billboardseries)
+* **exhibition texts**: [https://data.designmuseumgent.be/v1/id/texts](https://data.designmuseumgent.be/v1/id/texts)
 * **agents** (persons and organisations): [https://data.designmuseumgent.be/v1/id/agents](https://data.designmuseumgent.be/v1/id/agents)
 * **thesaurus** (concepts): [https://data.designmuseumgent.be/v1/id/concepts](https://data.designmuseumgent.be/v1/id/concepts)
 > to remove stress from the server, some of the collections work with pagination.

--- a/src/routes/texts.js
+++ b/src/routes/texts.js
@@ -1,7 +1,7 @@
 import {fetchTexts} from "../utils/parsers.js";
 
 export function requestTexts(app, BASE_URI) {
-    app.get('/id/texts/', async(get, res)=> {
+    app.get('/v1/id/texts/', async(get, res)=> {
         const _texts = await fetchTexts() // connect with Supabase and fetch data.
         const _range=_texts.length
         const catalogue = []; // initialize catalogue


### PR DESCRIPTION
Changed the endpoint for fetching texts to include versioning (/v1/id/texts/). Added corresponding information in the README file for new exhibition texts API endpoint.