### PR TITLE
Refactor route handlers and add ARK-compliant routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ single **entities** can be fetched using appropriate identifies (which are expos
 * **archive**: [https://data.designmuseumgent.be/v1/id/archive/TE_2003-010_Affiche](https://data.designmuseumgent.be/v1/id/archive/TE_2003-010_Affiche)
 * **concept**: [https://data.designmuseumgent.be/v1/id/concept/530006321](https://data.designmuseumgent.be/v1/id/concept/530006321)
 
-as this is not yet compliant with the flemish URI standard we have also added alternative routes, compliant to the EUR standard, making use of ARK. 
-* **exhibition**: [https://data.designmuseumgent.be/v1/id/ark:/29417/exhibition/TE_1993-009](https://data.designmuseumgent.be/v1/id/ark:/29417/exhibition/TE_1993-009)
+as this is not yet compliant with the flemish URI standard we have also added alternative routes, compliant to the EUR standard, making use of ARK. Both routes have the same payload. To make use of ARK, refactor the URLs above to the following syntax:
+> https://data.designmuseumgent.be/v1/id/ark:/29417/{type}/{referencenumber}
 
 ____ 
 

--- a/src/routes/agents.js
+++ b/src/routes/agents.js
@@ -43,7 +43,7 @@ export function requestAgents(app, BASE_URI) {
         }
     })
 
-    app.get('/v1/id/agent/:agentPID', async (req, res) => {
+    const agentHandler = async(req, res) => {
         try {
             const agentData = await fetchLDESRecordByAgentID(req.params.agentPID);
             if (!agentData) {
@@ -56,7 +56,10 @@ export function requestAgents(app, BASE_URI) {
             console.error(error);
             return res.status(500).send('Internal server error');
         }
-    });
+    }
+
+    app.get('/v1/id/agent/:agentPID', agentHandler)
+    app.get('/v1/id/ark:/29417/agent/:agentPID', agentHandler)
 }
 
 // ark

--- a/src/routes/archief.js
+++ b/src/routes/archief.js
@@ -2,8 +2,7 @@
 import {fetchArchiveByObjectNumber} from "../utils/parsers.js";
 
 export function requestArchive(app, BASE_URI) {
-    app.get('/v1/id/archive/:objectNumber', async(req, res)=> {
-        console.log(req.params.objectNumber)
+    const archiveHandler = async(req, res) => {
         const object = await fetchArchiveByObjectNumber(req.params.objectNumber);
 
         // construct id for isPartOf:
@@ -11,8 +10,9 @@ export function requestArchive(app, BASE_URI) {
         const exh_PURI = `${BASE_URI}id/exhibition/${PID}`
 
         //todo: remove when in LDES.
-        object[0]["LDES_raw"]["object"]["http://purl.org/dc/terms/isPartOf"]["cidoc:P16_used_specific_object"]["@id"] = exh_PURI
-
+        object[0]["LDES_raw"]["object"]["http://purl.org/dc/terms/isPartOf"]["cidoc:P16_used_specific_object"]["@id"] = exh_PUR
         res.send(object[0]["LDES_raw"])
-    })
+    }
+    app.get('/v1/id/archive/:objectNumber',archiveHandler)
+    app.get('/v1/id/ark:/29417/archive/:objectNumber',archiveHandler)
 }

--- a/src/routes/concept.js
+++ b/src/routes/concept.js
@@ -1,7 +1,7 @@
 import {fetchAllConcepts, fetchConcept} from "../utils/parsers.js";
 
 export function requestConcept(app, BASE_URI) {
-    app.get("/v1/id/concept/:id", async(req, res)=> {
+    const conceptHandler = async(req, res) => {
         // await data from GET request DB
         let _id = "https://stad.gent/id/concept/"+req.params.id
         console.log(_id)
@@ -19,6 +19,9 @@ export function requestConcept(app, BASE_URI) {
                 error: "there is no concept in our catalogue with that id"
             })
         }
-    })
+    }
+
+    app.get("/v1/id/concept/:id", conceptHandler)
+    app.get("/v1/id/ark:/29417/concept/:id", conceptHandler)
 }
 

--- a/src/routes/objects.js
+++ b/src/routes/objects.js
@@ -35,7 +35,7 @@ export function requestObjects(app, BASE_URI) {
 
       let object = {};
       object["@context"] = [
-        "https://apidg.gent.be/op…erfgoed-object-ap.jsonld",
+        "https://apidg.gent.be/operfgoed-object-ap.jsonld",
         "https://apidg.gent.be/op…xt/generiek-basis.jsonld",
       ]
 
@@ -59,8 +59,8 @@ export function requestObjects(app, BASE_URI) {
 }
 
 export function requestObject(app, BASE_URI) {
-  app.get("/v1/id/object/:objectNumber.:format?", async (req, res, next) => {
 
+  const objectHandler = async(req, res) => {
     // 1. resolve to special pages
     if (req.params.objectNumber === "removed") {
       return res.status(410).json({
@@ -163,6 +163,7 @@ export function requestObject(app, BASE_URI) {
     } catch (e) {
       res.status(503).send(e);
     }
-
-  });
+  }
+  app.get("/v1/id/object/:objectNumber.:format?",  objectHandler);
+  app.get("/v1/id/ark:/29417/object/:objectNumber.:format?",  objectHandler);
 }


### PR DESCRIPTION
Consolidate route handler functions into reusable handlers for concepts, archives, objects, and agents. Introduce ARK-compliant routes alongside existing routes to support alternative URI standards, ensuring both route types return the same payload.