### PR TITLE
update color-api - add query possibility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,12 @@ ____
 the color-api exposes the collection based on colors that objects have. Exploring different _color systems_, the user has the capability to retrieve data on the collection based on a given **color** and using the following syntax:
 > https://data.designmuseumgent.be/v1/color-api/{color}
 
-example using "_vanilla_" as input color: 
+to fetch and retrieve not the entire object but only a list of images with a reference to the physical object, the following query can be used:
+> https://data.designmuseumgent.be/v1/color-api/{color}?image=true
+
+example using **vanilla** as input color: 
 >https://data.designmuseumgent.be/v1/color-api/vanilla
+>https://data.designmuseumgent.be/v1/color-api/vanilla?image=true
 
 a full list of the used color system is exposed here:
 >https://data.designmuseumgent.be/v1/colors/

--- a/src/routes/colors.js
+++ b/src/routes/colors.js
@@ -6,14 +6,19 @@ function addImageUri(filteredObjects, object, BASE_URI) {
     if (object["iiif_image_uris"]) {
         object["iiif_image_uris"].forEach(uri => {
             filteredObjects.push({
-                "@context": "http://www.cidoc-crm.org/cidoc-crm/",
+                "@context": [
+                    "https://data.vlaanderen.be/doc/applicatieprofiel/cultureel-erfgoed-object/erkendestandaard/2021-04-22/context/cultureel-erfgoed-object-ap.jsonld",
+                    {
+                        "cidoc": "http://www.cidoc-crm.org/cidco-crm/"
+                    }
+                ],
                 "@id": uri,
                 "@type": "E38_Image",
-                "P1_is_identified_by": uri,
-                "P138_represents": {
+                "cidoc:P1_is_identified_by": uri,
+                "cidoc:P138_represents": {
                     "@id": `${BASE_URI}id/${object["objectNumber"]}`,
                     "@type": "E22_Man-Made_Object",
-                    "P1_is_identified_by": `${BASE_URI}id/object/${object["objectNumber"]}`
+                    "cidoc:P1_is_identified_by": `${BASE_URI}id/object/${object["objectNumber"]}`
                 }
             });
         })
@@ -55,11 +60,10 @@ export function requestByColor(app, BASE_URI) {
 
         res.status(200).send({
             "@context": [
-                "https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/erkendestandaard/2022-04-21/context/DCAT-AP-VL-20.jsonld",
                 "https://data.vlaanderen.be/doc/applicatieprofiel/cultureel-erfgoed-event/erkendestandaard/2021-04-22/context/cultureel-erfgoed-event-ap.jsonld",
                 "https://data.vlaanderen.be/doc/applicatieprofiel/cultureel-erfgoed-object/erkendestandaard/2021-04-22/context/cultureel-erfgoed-object-ap.jsonld",
                 {
-                    cidoc: "https://www.cidoc-crm.org/cidco-crm/"
+                    "cidoc": "http://www.cidoc-crm.org/cidco-crm/"
                 }
             ],
             "@type": "GecureerdeCollectie",


### PR DESCRIPTION
add query possibility to color-api so only the images (digital objects are returned) together with a reference to the physical object. ("depicts")