### PR TITLE
Fix condition to determine empty agent collection

### DIFF
--- a/src/routes/collections/agents.js
+++ b/src/routes/collections/agents.js
@@ -56,7 +56,7 @@ export function requestAgents(app, BASE_URI) {
             "GecureerdeCollectie.bestaatUit": filteredAgentsData
         })
 
-        if (agents.length === 0) {
+        if (filteredAgentsData.length === 0) {
             return res.status(404).send('No agents found')
         }
 


### PR DESCRIPTION
The condition now correctly checks the length of filteredAgentsData instead of agents. This ensures that the response status properly reflects whether any agents were found.